### PR TITLE
support for OS_TEST_NETWORK

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -19,4 +19,5 @@ openstack:
   test:
     image:  OS_TEST_IMAGE
     flavor: OS_TEST_FLAVOR
+    network: OS_TEST_NETWORK
     

--- a/schema/opnfv-promise.yang
+++ b/schema/opnfv-promise.yang
@@ -30,6 +30,15 @@ module opnfv-promise {
   feature multi-provider {
     description "When enabled, provides resource management across multiple providers";
   }
+
+  typedef reference-identifier {
+    description "defines valid formats for external reference id";
+    type union {
+      type yang:uuid;
+      type inet:uri;
+      type uint32;
+    }
+  }
   
   grouping resource-utilization {
     container capacity {
@@ -542,19 +551,18 @@ module opnfv-promise {
       }
       leaf name   { type string; mandatory true; }
       leaf image  {
-        type union {
-          type yang:uuid;
-          type inet:uri;
-        }
+        type reference-identifier;
         mandatory true;
       }
       leaf flavor {
-        type union {
-          type yang:uuid;
-          type inet:uri;
-        }
+        type reference-identifier;
         mandatory true;
       }
+      leaf network {
+        type reference-identifier;
+        description "optional, will assign default network if not provided";
+      }
+      
       // TODO: consider supporting a template-id (such as HEAT) for more complex instantiation
       
       leaf reservation-id {

--- a/spec/promise-intents.coffee
+++ b/spec/promise-intents.coffee
@@ -236,15 +236,18 @@ module.exports =
       .save()
       .then (instance) =>
         url = provider.get 'services.compute.endpoint'
+        payload =
+          server:
+            name: input.get 'name'
+            imageRef: input.get 'image'
+            flavorRef: input.get 'flavor'
+        if (input.get 'network')?
+          payload.server.networks = uuid: input.get 'network'
+
         request = @parent.require 'superagent'
         request
           .post "#{url}/servers"
-          .send {
-            server:
-              name: input.get 'name'
-              imageRef: input.get 'image'
-              flavorRef: input.get 'flavor'
-          }
+          .send payload
           .set 'X-Auth-Token', provider.get 'token'
           .set 'Accept', 'application/json'
           .end (err, res) =>

--- a/test/promise-intents.coffee
+++ b/test/promise-intents.coffee
@@ -145,12 +145,15 @@ describe "promise", ->
 
       it "should create a new server in target provider without error", (done) ->
         @timeout 5000
+        test = config.get 'openstack.test'
         app.access('opnfv-promise').invoke 'create-instance',
           'provider-id': provider.id
           name: 'promise-test-no-reservation'
-          image:  config.get 'openstack.test.image'
-          flavor: config.get 'openstack.test.flavor'
+          image:   test.image
+          flavor:  test.flavor
+          network: test.network
         .then (res) ->
+          debug res.get()
           res.get('result').should.equal 'ok'
           instance_id = res.get('instance-id')
           done()
@@ -212,13 +215,16 @@ describe "promise", ->
 
       it "should create a new server in target provider (with reservation) without error", (done) ->
         @timeout 5000
+        test = config.get 'openstack.test'
         app.access('opnfv-promise').invoke 'create-instance',
           'provider-id': provider.id
           name: 'promise-test-no-reservation'
-          image:  config.get 'openstack.test.image'
-          flavor: config.get 'openstack.test.flavor'
+          image:  test.image
+          flavor: test.flavor
+          network: test.network
           'reservation-id': reservation.id
         .then (res) ->
+          debug res.get()
           res.get('result').should.equal 'ok'
           allocation = id: res.get('instance-id')
           done()


### PR DESCRIPTION
extended opnfv-promise schema and related operations to allow create-instance to accept a *network* reference-identifier.